### PR TITLE
Add ubuntu kernel 5.17.5 to tested section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ the Installation Steps can be improved.
 
 - RHEL 8.4 (kernel 4.18.0)
 
-- Ubuntu 22.04 (kernel 5.15)
+- Ubuntu 22.04 (kernel 5.15 and 5.17.5)
 
 - Void Linux (kernel 5.18)
 


### PR DESCRIPTION
I have installed this driver on Ubuntu 22.04 - Kernel 5.17.5.

```bash
❯ lsusb | grep -i 88x2bu
Bus 001 Device 003: ID 0bda:b812 Realtek Semiconductor Corp. RTL88x2bu [AC1200 Techkey]
❯ lsmod | grep 88x2bu
88x2bu               3383296  0
cfg80211              978944  5 iwlmvm,88x2bu,iwlmei,iwlwifi,mac80211
❯ uname -ra
Linux pop-os 5.17.5-76051705-generic #202204271406~1651504840~22.04~63e51bd SMP PREEMPT Mon May 2 15: x86_64 x86_64 x86_64 GNU/Linux
```