### PR TITLE
Add hack to support EL 8.6 kernels (4.18.0-372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ the Installation Steps can be improved.
 
 - Raspberry Pi Desktop (2022-07-01) (x86 32 bit) (kernel 5.10)
 
-- RHEL 8.4 (kernel 4.18.0)
+- RHEL 8.4 and 8.6 (kernel 4.18.0)
 
 - Ubuntu 22.04 (kernel 5.15 and 5.17.5)
 
@@ -565,6 +565,21 @@ https://github.com/morrownr/USB-WiFi
 Question: Will you put volunteers to work?
 
 Answer: Yes. Post a message in `Issues` or `Discussions` if interested.
+
+-----
+
+Question: Were compromises made to make this work on EL8 (RHEL, CentOS,
+Rocky, etc) distributions?
+
+Answer: Yes. EL8 distribution kernels contain many backports of features
+and fixes from newer kernels, but sometimes in ways that break drivers
+that are not specifically tested against. For EL 8.6 specifically, the
+driver contains a significant hack that ignores the current link state
+of the adapter when transmitting or receiving frames. This matches the
+behavior of ancient drivers for other chipsets that do work on EL 8.6
+(as they do not check link status at all), but is really a kludge to
+work around a station accounting issue on these kernels. Only Ad-Hoc and 
+Station mode have been tested.
 
 -----
 

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -4754,8 +4754,10 @@ u8 adapter_allow_bmc_data_rx(_adapter *adapter)
 	if (MLME_IS_AP(adapter))
 		return 0;
 
+#if !defined(RHEL8)
 	if (rtw_linked_check(adapter) == _FALSE)
 		return 0;
+#endif
 
 	return 1;
 }

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -5159,12 +5159,14 @@ s32 rtw_xmit(_adapter *padapter, _pkt **ppkt, u16 os_qid)
 	if (IS_CH_WAITING(adapter_to_rfctl(padapter)))
 		return -1;
 
+#if !defined(RHEL8)
 	if ((rtw_linked_check(padapter) == _FALSE)
 #ifdef CONFIG_LAYER2_ROAMING
 		&&(!padapter->mlmepriv.roam_network)
 #endif
 	   )
 		return -1;
+#endif
 
 	if (start == 0)
 		start = rtw_get_current_time();


### PR DESCRIPTION
...by ignoring the link state when transmitting and receiving frames (matching the behavior of ancient drivers for other chipsets that work on EL8.6). Fixes #90.