### PR TITLE
Use make uninstall when dkms not present on remove-driver.sh

### DIFF
--- a/remove-driver.sh
+++ b/remove-driver.sh
@@ -50,7 +50,12 @@ done
 echo "Running ${SCRIPT_NAME} version ${SCRIPT_VERSION}"
 echo "Starting removal..."
 
-dkms remove -m ${DRV_NAME} -v ${DRV_VERSION} --all
+if ! command -v dkms >/dev/null 2>&1
+then
+	make uninstall
+else
+        dkms remove -m ${DRV_NAME} -v ${DRV_VERSION} --all
+fi
 RESULT=$?
 
 # RESULT will be 3 if there are no instances of module to remove


### PR DESCRIPTION
Thanks for this repo and stable driver! Found it from [this blog](https://catzy007.github.io/loader.html?post=2021-09-03-my-attempt-to-5ghz-usb-wifi-access-point) when I needed to use an existing RTL 88X2BU dongle I had as an AP. 

I'm on Ubuntu 22.02 and DKMS doesn't come installed by default. 

`sudo ./install_driver.sh` went well, but after using and attempting to uninstall the current state was:

```
% sudo ./remove-driver.sh
Running remove-driver.sh version 20221007
Starting removal...
./remove-driver.sh: line 53: dkms: command not found
An error occurred. dkms remove error = 127
Please report this error.
```

Peeking into the Makefile I noticed there was a `make uninstall`  here: https://github.com/morrownr/88x2bu-20210702/blob/main/Makefile#L2512

And studying your install script it seems like you test for DKMS presence here: https://github.com/morrownr/88x2bu-20210702/blob/main/install-driver.sh#L81-L105

As such, I added the same test and this allowed the driver to be removed.

```
 % sudo ./remove-driver.sh
Running remove-driver.sh version 20221007
Starting removal...
rm -f /lib/modules/5.15.0-53-generic/kernel/drivers/net/wireless//88x2bu.ko
/sbin/depmod -a 5.15.0-53-generic
Deleting 88x2bu.conf from /etc/modprobe.d
Deleting rtw88_8822bu.conf from /etc/modprobe.d
Deleting source files from /usr/src/rtl88x2bu-5.13.1
The driver was removed successfully.
You may now delete the driver directory if desired.
Do you want to reboot now? (recommended) [y/N] N
```

Thanks again! 