### PR TITLE
Added support of new kernel for rhel9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ ifeq ($(shell test $(RHEL_SVER) -ge 284; echo $$?),0)
 EXTRA_CFLAGS += -DRHEL92 -DRHEL88
 endif
 endif
-
 endif
 
 ########################## WIFI IC ############################
@@ -1366,7 +1365,7 @@ endif
 EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 
 ifeq ($(CONFIG_RTW_MBO), y)
-EXTRA_CFLAGS += -DCONFIG_RTW_MBO -DCONFIG_RTW_80211K -DCONFIG_RTW_WNM -DCONFIG_RTW_BTM_ROAM
+EXTRA_CFLAGS += -DCONFIG_RTW_MBO -DCONFIG_RTW_WNM -DCONFIG_RTW_BTM_ROAM
 EXTRA_CFLAGS += -DCONFIG_RTW_80211R
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,26 @@ EXTRA_LDFLAGS += --strip-debug
 CONFIG_AUTOCFG_CP = n
 
 RHEL_VER := $(shell echo `grep '^ID_LIKE'  /etc/os-release |grep -qi 'fedora' && grep '^VERSION_ID' /etc/os-release | cut -f2 -d= | cut -c2`)
-ifeq (${RHEL_VER},8)
-EXTRA_CFLAGS += -DRHEL8
+ifdef RHEL_VER
 ifdef KVER
 RHEL_SVER := $(shell echo $(KVER) |sed -e 's/^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-\([0-9][0-9]*\).*/\1/')
 else
 RHEL_SVER := $(shell uname -r |sed -e 's/^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-\([0-9][0-9]*\).*/\1/')
 endif
+
+ifeq (${RHEL_VER},8)
+EXTRA_CFLAGS += -DRHEL8
 ifeq ($(shell test $(RHEL_SVER) -ge 477; echo $$?),0)
 EXTRA_CFLAGS += -DRHEL88
 endif
+endif
+
+ifeq (${RHEL_VER},9)
+ifeq ($(shell test $(RHEL_SVER) -ge 284; echo $$?),0)
+EXTRA_CFLAGS += -DRHEL92 -DRHEL88
+endif
+endif
+
 endif
 
 ########################## WIFI IC ############################

--- a/core/rtw_mbo.c
+++ b/core/rtw_mbo.c
@@ -534,7 +534,7 @@ static void  rtw_mbo_non_pref_chans_set(
 			break;
 		}
 		
-	} while(param != '\0');
+	} while(*param != '\0');
 	
 }
 

--- a/hal/hal_hci/hal_usb.c
+++ b/hal/hal_hci/hal_usb.c
@@ -26,7 +26,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&precvpriv->recv_tasklet,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0) && !defined(RHEL92))
 		     (void(*)(unsigned long))usb_recv_tasklet,
 #else
 		     (void *)usb_recv_tasklet,

--- a/hal/rtl8822b/usb/rtl8822bu_xmit.c
+++ b/hal/rtl8822b/usb/rtl8822bu_xmit.c
@@ -878,7 +878,7 @@ s32	rtl8822bu_init_xmit_priv(PADAPTER padapter)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&pxmitpriv->xmit_tasklet,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0) && !defined(RHEL92))
 		     (void(*)(unsigned long))rtl8822bu_xmit_tasklet,
 #else
 		     (void *)rtl8822bu_xmit_tasklet,

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1309,7 +1309,7 @@ u32 _rtw_down_sema(_sema *sema)
 inline void thread_exit(_completion *comp)
 {
 #ifdef PLATFORM_LINUX
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || defined(RHEL92))
 	kthread_complete_and_exit(comp, 0);
 #else
 	complete_and_exit(comp, 0);


### PR DESCRIPTION
These are the changes needed to successfully compile the driver for rhel 9.2 with kernel 5.14.0-284.11.1.el9_2.x86_64