### PR TITLE
Fixup for stale kickoff removal in wireless regulator API

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,12 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39)) && !defined(RHEL94)
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) \
+       && ((LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39)) \
+		|| (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))) \
+	&& ((LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 13)) \
+		|| (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))) \
+	&& (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 4))) && !defined(RHEL94)
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
Cope with the fix in stable 6.3.13 commit bf353116d1bf, 6.5-rc1 commte8c2af660ba0 and and 6.1.39 commit 132b7129c5fe LTS "wifi: cfg80211: fix regulatory disconnect with OCB/NAN". That is the removal of REGULATORY_IGNORE_STALE_KICKOFF from the wireless regulator internal API to fix any driver that allowed OCB/NAN.


I made this patch for the compilation error: wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF.
It was included and expanded in armbian https://github.com/armbian/build/blob/84e4a26bb09e9bc8401d3768c8158782ea601fc4/patch/misc/wireless-rtl88x2bu-wireless-ignore-stale-kickoff-removal.patch

The issue was this API change fixup was backported to stable/lts branches of the kernel.
This patch copes with this API change backports in al known branches it was included in, that
is in 6.1, 6.3, and 6.4 and above.

THis is for completeness as the current code which treat all kernel below 6.1.39 as including this API change will only break if one attempts to build an older tag of the 6.3 and 6.4 branches (or if one try to build the 6.2 branch). Most likely if one does regression testing. So the code already works in most cases.

Closes issue #165 