### PR TITLE
Added support for rhel8.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ EXTRA_CFLAGS += -DRHEL8
 ifeq ($(shell test $(RHEL_SVER) -ge 477; echo $$?),0)
 EXTRA_CFLAGS += -DRHEL88
 endif
+ifeq ($(shell test $(RHEL_SVER) -ge 513; echo $$?),0)
+EXTRA_CFLAGS += -DRHEL89
+endif
 endif
 
 ifeq (${RHEL_VER},9)
@@ -68,7 +71,7 @@ ifeq ($(shell test $(RHEL_SVER) -ge 284; echo $$?),0)
 EXTRA_CFLAGS += -DRHEL92 -DRHEL88
 endif
 ifeq ($(shell test $(RHEL_SVER) -ge 362; echo $$?),0)
-EXTRA_CFLAGS += -DRHEL93
+EXTRA_CFLAGS += -DRHEL89
 endif
 endif
 endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -465,7 +465,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 		 */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0) || defined(RHEL93))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0) || defined(RHEL89))
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false, 0);
 #else
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
@@ -484,7 +484,7 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 		goto exit;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2) || defined(RHEL88))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)  || defined(RHEL93))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)  || defined(RHEL89))
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
 #else
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);


### PR DESCRIPTION
These are the changes needed to successfully compile the driver for rhel 8.9 and maintain backward compatibility with the older rhel version