### PR TITLE
Added rhel9.4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ endif
 ifeq ($(shell test $(RHEL_SVER) -ge 362; echo $$?),0)
 EXTRA_CFLAGS += -DRHEL89
 endif
+ifeq ($(shell test $(RHEL_SVER) -ge 427; echo $$?),0)
+EXTRA_CFLAGS += -DRHEL94
+endif
 endif
 endif
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -5405,7 +5405,7 @@ exit:
 }
 
 static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)) || defined(RHEL94)
 	struct cfg80211_ap_update *info)
 #else
 	struct cfg80211_beacon_data *info)
@@ -5416,7 +5416,7 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)) || defined(RHEL94)
 	ret = rtw_add_beacon(adapter, info->beacon.head, info->beacon.head_len, info->beacon.tail, info->beacon.tail_len);
 #else
 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
@@ -8455,7 +8455,7 @@ static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
 #else
 	u8 *peer,
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)) || defined(RHEL94)
 	int link_id,
 #endif
 	u8 action_code,

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,7 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 39)) && !defined(RHEL94)
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
These are the changes needed to successfully compile the driver for rhel9.4. Tested with rhel9.4 and rhel8.9