### PR TITLE
fix: multiple definition of aes_encrypt

### DIFF
--- a/core/crypto/aes-ctr.c
+++ b/core/crypto/aes-ctr.c
@@ -30,13 +30,13 @@ int aes_ctr_encrypt(const u8 *key, size_t key_len, const u8 *nonce,
 	u8 *pos = data;
 	u8 counter[AES_BLOCK_SIZE], buf[AES_BLOCK_SIZE];
 
-	ctx = aes_encrypt_init(key, key_len);
+	ctx = aes_encrypt_rtl8822b_init(key, key_len);
 	if (ctx == NULL)
 		return -1;
 	os_memcpy(counter, nonce, AES_BLOCK_SIZE);
 
 	while (left > 0) {
-		aes_encrypt(ctx, counter, buf);
+		aes_encrypt_rtl8822b(ctx, counter, buf);
 
 		len = (left < AES_BLOCK_SIZE) ? left : AES_BLOCK_SIZE;
 		for (j = 0; j < len; j++)
@@ -50,7 +50,7 @@ int aes_ctr_encrypt(const u8 *key, size_t key_len, const u8 *nonce,
 				break;
 		}
 	}
-	aes_encrypt_deinit(ctx);
+	aes_encrypt_rtl8822b_deinit(ctx);
 	return 0;
 }
 

--- a/core/crypto/aes-gcm.c
+++ b/core/crypto/aes-gcm.c
@@ -154,7 +154,7 @@ static void aes_gctr(void *aes, const u8 *icb, const u8 *x, size_t xlen, u8 *y)
 	os_memcpy(cb, icb, AES_BLOCK_SIZE);
 	/* Full blocks */
 	for (i = 0; i < n; i++) {
-		aes_encrypt(aes, cb, ypos);
+		aes_encrypt_rtl8822b(aes, cb, ypos);
 		xor_block(ypos, xpos);
 		xpos += AES_BLOCK_SIZE;
 		ypos += AES_BLOCK_SIZE;
@@ -164,7 +164,7 @@ static void aes_gctr(void *aes, const u8 *icb, const u8 *x, size_t xlen, u8 *y)
 	last = x + xlen - xpos;
 	if (last) {
 		/* Last, partial block */
-		aes_encrypt(aes, cb, tmp);
+		aes_encrypt_rtl8822b(aes, cb, tmp);
 		for (i = 0; i < last; i++)
 			*ypos++ = *xpos++ ^ tmp[i];
 	}
@@ -175,13 +175,13 @@ static void * aes_gcm_init_hash_subkey(const u8 *key, size_t key_len, u8 *H)
 {
 	void *aes;
 
-	aes = aes_encrypt_init(key, key_len);
+	aes = aes_encrypt_rtl8822b_init(key, key_len);
 	if (aes == NULL)
 		return NULL;
 
 	/* Generate hash subkey H = AES_K(0^128) */
 	os_memset(H, 0, AES_BLOCK_SIZE);
-	aes_encrypt(aes, H, H);
+	aes_encrypt_rtl8822b(aes, H, H);
 	wpa_hexdump_key(_MSG_EXCESSIVE_, "Hash subkey H for GHASH",
 			H, AES_BLOCK_SIZE);
 	return aes;
@@ -275,7 +275,7 @@ int aes_gcm_ae(const u8 *key, size_t key_len, const u8 *iv, size_t iv_len,
 
 	/* Return (C, T) */
 
-	aes_encrypt_deinit(aes);
+	aes_encrypt_rtl8822b_deinit(aes);
 
 	return 0;
 }
@@ -307,7 +307,7 @@ int aes_gcm_ad(const u8 *key, size_t key_len, const u8 *iv, size_t iv_len,
 	/* T' = MSB_t(GCTR_K(J_0, S)) */
 	aes_gctr(aes, J0, S, sizeof(S), T);
 
-	aes_encrypt_deinit(aes);
+	aes_encrypt_rtl8822b_deinit(aes);
 
 	if (os_memcmp_const(tag, T, 16) != 0) {
 		wpa_printf(_MSG_EXCESSIVE_, "GCM: Tag mismatch");

--- a/core/crypto/aes-internal-enc.c
+++ b/core/crypto/aes-internal-enc.c
@@ -93,7 +93,7 @@ d##3 = TE0(s##3) ^ TE1(s##0) ^ TE2(s##1) ^ TE3(s##2) ^ rk[4 * i + 3]
 }
 
 
-void * aes_encrypt_init(const u8 *key, size_t len)
+void * aes_encrypt_rtl8822b_init(const u8 *key, size_t len)
 {
 	u32 *rk;
 	int res;
@@ -114,7 +114,7 @@ void * aes_encrypt_init(const u8 *key, size_t len)
 }
 
 
-int aes_encrypt(void *ctx, const u8 *plain, u8 *crypt)
+int aes_encrypt_rtl8822b(void *ctx, const u8 *plain, u8 *crypt)
 {
 	u32 *rk = ctx;
 	rijndaelEncrypt(ctx, rk[AES_PRIV_NR_POS], plain, crypt);
@@ -122,7 +122,7 @@ int aes_encrypt(void *ctx, const u8 *plain, u8 *crypt)
 }
 
 
-void aes_encrypt_deinit(void *ctx)
+void aes_encrypt_rtl8822b_deinit(void *ctx)
 {
 	os_memset(ctx, 0, AES_PRIV_SIZE);
 	rtw_mfree(ctx, AES_PRIV_SIZE);

--- a/core/crypto/aes-omac1.c
+++ b/core/crypto/aes-omac1.c
@@ -50,7 +50,7 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 	if (TEST_FAIL())
 		return -1;
 
-	ctx = aes_encrypt_init(key, key_len);
+	ctx = aes_encrypt_rtl8822b_init(key, key_len);
 	if (ctx == NULL)
 		return -1;
 	os_memset(cbc, 0, AES_BLOCK_SIZE);
@@ -81,12 +81,12 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 			}
 		}
 		if (left > AES_BLOCK_SIZE)
-			aes_encrypt(ctx, cbc, cbc);
+			aes_encrypt_rtl8822b(ctx, cbc, cbc);
 		left -= AES_BLOCK_SIZE;
 	}
 
 	os_memset(pad, 0, AES_BLOCK_SIZE);
-	aes_encrypt(ctx, pad, pad);
+	aes_encrypt_rtl8822b(ctx, pad, pad);
 	gf_mulx(pad);
 
 	if (left || total_len == 0) {
@@ -110,8 +110,8 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 
 	for (i = 0; i < AES_BLOCK_SIZE; i++)
 		pad[i] ^= cbc[i];
-	aes_encrypt(ctx, pad, mac);
-	aes_encrypt_deinit(ctx);
+	aes_encrypt_rtl8822b(ctx, pad, mac);
+	aes_encrypt_rtl8822b_deinit(ctx);
 	return 0;
 }
 

--- a/core/crypto/aes.h
+++ b/core/crypto/aes.h
@@ -11,9 +11,9 @@
 
 #define AES_BLOCK_SIZE 16
 
-void * aes_encrypt_init(const u8 *key, size_t len);
-int aes_encrypt(void *ctx, const u8 *plain, u8 *crypt);
-void aes_encrypt_deinit(void *ctx);
+void * aes_encrypt_rtl8822b_init(const u8 *key, size_t len);
+int aes_encrypt_rtl8822b(void *ctx, const u8 *plain, u8 *crypt);
+void aes_encrypt_rtl8822b_deinit(void *ctx);
 void * aes_decrypt_init(const u8 *key, size_t len);
 int aes_decrypt(void *ctx, const u8 *crypt, u8 *plain);
 void aes_decrypt_deinit(void *ctx);

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -1587,7 +1587,7 @@ static sint aes_cipher(u8 *key, uint	hdrlen,
 
 
 #if NEW_CRYPTO
-u32 rtw_aes_encrypt(_adapter *padapter, u8 *pxmitframe)
+u32 rtw_aes_encrypt_rtl8822b(_adapter *padapter, u8 *pxmitframe)
 {
 	/* Intermediate Buffers */
 	struct pkt_attrib *pattrib = &((struct xmit_frame *)pxmitframe)->attrib;
@@ -1666,7 +1666,7 @@ u32 rtw_aes_encrypt(_adapter *padapter, u8 *pxmitframe)
 	return res;
 }
 #else
-u32	rtw_aes_encrypt(_adapter *padapter, u8 *pxmitframe)
+u32	rtw_aes_encrypt_rtl8822b(_adapter *padapter, u8 *pxmitframe)
 {
 	/* exclude ICV */
 

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -2078,7 +2078,7 @@ static s32 xmitframe_swencrypt(_adapter *padapter, struct xmit_frame *pxmitframe
 			break;
 		case _AES_:
 		case _CCMP_256_:
-			rtw_aes_encrypt(padapter, (u8 *)pxmitframe);
+			rtw_aes_encrypt_rtl8822b(padapter, (u8 *)pxmitframe);
 			break;
 		case _GCMP_:
 		case _GCMP_256_:

--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -366,7 +366,7 @@ void rtw_seccalctkipmic(
 	u8 *Miccode,
 	u8   priority);
 
-u32 rtw_aes_encrypt(_adapter *padapter, u8 *pxmitframe);
+u32 rtw_aes_encrypt_rtl8822b(_adapter *padapter, u8 *pxmitframe);
 u32 rtw_tkip_encrypt(_adapter *padapter, u8 *pxmitframe);
 void rtw_wep_encrypt(_adapter *padapter, u8  *pxmitframe);
 


### PR DESCRIPTION
Error message:
```text
  AR      drivers/built-in.a
  AR      built-in.a
  AR      vmlinux.a
  LD      vmlinux.o
ld: drivers/net/wireless/realtek/rtl8822b/core/crypto/aes-internal-enc.o: in function `aes_encrypt':
aes-internal-enc.c:(.text+0x80): multiple definition of `aes_encrypt'; lib/crypto/aes.o:aes.c:(.text+0x870): first defined here
ld: drivers/net/wireless/realtek/rtl8822b/core/crypto/aes-internal-enc.o: in function `__pfx_aes_encrypt':
aes-internal-enc.c:(.text+0x70): multiple definition of `__pfx_aes_encrypt'; lib/crypto/aes.o:aes.c:(.text+0x860): first defined here
make[2]: *** [scripts/Makefile.vmlinux_o:89: vmlinux.o] Error 1
make[1]: *** [/usr/src/linux-6.6.67-gentoo/Makefile:1148: vmlinux_o] Error 2
make: *** [Makefile:234: __sub-make] Error 2
```

I tested for Linux kernel 6.6.67-gentoo.


I used following script to install directly in kernel to  "drivers/net/wireless/realtek/" path.

```bash
#!/bin/bash
RTL=rtl8822b # rtl8812au
FOLDERS=88x2bu-20210702

CONF_MOD=CONFIG_RTL8822BU

# mkdir -p "/lib/modules/$(uname -r)/build"
mkdir -p "/lib/modules/$(cat /usr/src/linux/include/config/kernel.release)/build" # gentoo way

# - remove folder in kernel
rm -r /usr/src/linux/drivers/net/wireless/realtek/${RTL} &> /dev/null
# - copy folder to kernel
cp -r /usr/local/src/${FOLDERS} /usr/src/linux/drivers/net/wireless/realtek/${RTL}
# - replace line in Makefile, we include in kernel
sed -i "s/export ${CONF_MOD} = m/export ${CONF_MOD} = y/" /usr/src/linux/drivers/net/wireless/realtek/${RTL}/Makefile

# - add line to uplevel Makefile to our folder
echo 'obj-$('${CONF_MOD}')		+= '"${RTL}/" >> /usr/src/linux/drivers/net/wireless/realtek/Makefile
# - create/restore .back for kernel config
if [ -e /usr/src/linux/drivers/net/wireless/realtek/Kconfig.back ] ; then
    cp /usr/src/linux/drivers/net/wireless/realtek/Kconfig.back /usr/src/linux/drivers/net/wireless/realtek/Kconfig
else
    cp /usr/src/linux/drivers/net/wireless/realtek/Kconfig /usr/src/linux/drivers/net/wireless/realtek/Kconfig.back
fi
# - add section to Kconfig with path to our Kconfig
# | sed 's#source \"drivers/net/wireless/realtek/rtw88/Kconfig\"##' > 
head -n -1 /usr/src/linux/drivers/net/wireless/realtek/Kconfig > /tmp/Kconfig
echo "source \"drivers/net/wireless/realtek/${RTL}/Kconfig\"" >> /tmp/Kconfig
echo >> /tmp/Kconfig
echo 'endif # WLAN_VENDOR_REALTEK' >> /tmp/Kconfig
mv /tmp/Kconfig /usr/src/linux/drivers/net/wireless/realtek/Kconfig


# - remove rtw88
echo "" > /usr/src/linux/drivers/net/wireless/realtek/rtw88/Kconfig 
echo "" > /usr/src/linux/drivers/net/wireless/realtek/rtw88/Makefile
```