### PR TITLE
Fix: add from_timer() helper for kernel >=6.14 (tested on 6.16)

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -357,6 +357,16 @@ static inline void timer_hdl(struct timer_list *in_timer)
 static inline void timer_hdl(unsigned long cntx)
 #endif
 {
+ #include <linux/version.h>
+#include <linux/timer.h>
+
+/* --- Fix for kernel >=6.14: missing from_timer() helper --- */
+#ifndef from_timer
+#define from_timer(var, callback_timer, fieldname) \
+    ({ typeof(var) __tmp = (var); \
+       (_timer *)((char *)(callback_timer) - offsetof(_timer, fieldname)); })
+#endif
+/* --- end patch --- */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
 	_timer *ptimer = from_timer(ptimer, in_timer, timer);
 #else


### PR DESCRIPTION
Fix build error on kernel 6.16 (missing from_timer helper)

This patch adds a local definition of the from_timer() helper in
include/osdep_service_linux.h for kernels ≥6.14. Without this, DKMS
builds fail on modern kernels (e.g., 6.16.8+kali-amd64) with
'implicit declaration of function from_timer'.

Tested on:
- Kali Linux 2025, kernel 6.16.8+kali-amd64
- GCC 15.2.0
- DKMS 3.2.2

Driver builds and loads successfully after this change.