### PR TITLE
Fix kernel 6.18 compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ the hardware to test the above.
 
 - Kernels: 5.10 - 5.11 (Realtek)
 - Kernels: 5.12 - 6.14  (community support)
+- Kernels: 6.18.4 and later (debian based distros only with gcc 15.2)
 
 Note: Kernels earlier than 5.10 may work but are not tested or
 supported.
@@ -101,6 +102,7 @@ supported.
 ### Tested Compilers
 
 - gcc 12, 13 and 14
+- gcc 15.2 (only for kernels 6.18.4 and later)
 
 ### Tested Linux Distributions
 
@@ -111,11 +113,11 @@ which can be provided via PR or message in Issues.
 
 - [Armbian](https://www.armbian.com/) (kernel 5.15) (Rock 4 SE (Rock 4b image with xfce))
 
-- [Debian](https://www.debian.org/) (kernels 5.10, 5.15 and 6.1)
+- [Debian](https://www.debian.org/) (kernels 5.10, 5.15, 6.1, 6.18.4)
 
 - [Fedora](https://getfedora.org) Fedora 38 (6.2.13-300)
 
-- [Kali Linux](https://www.kali.org/) (kernel 6.3)
+- [Kali Linux](https://www.kali.org/) (kernel 6.3, 6.18.4)
 
 - [Manjaro](https://manjaro.org) (kernel 5.15)
 
@@ -170,6 +172,7 @@ OpenWRT so it is strongly advised to use the already supported chipsets.
 * NetGear A6150
 * TRENDnet TEW-808UBM
 * jjPlus WMU6202 miniPCIe - USB
+* TP-Link Archer T4U ver.3 - USB (Realtek 802.11ac NIC 2357:0115)
 - Numerous additional adapters that are based on the supported chipsets
 
 Note: If you are looking for information about what adapter to buy,

--- a/core/crypto/sha256-prf.c
+++ b/core/crypto/sha256-prf.c
@@ -15,7 +15,7 @@
 
 
 /**
- * sha256_prf - SHA256-based Pseudo-Random Function (IEEE 802.11r, 8.5.1.5.2)
+ * rtw_sha256_prf - SHA256-based Pseudo-Random Function (IEEE 802.11r, 8.5.1.5.2)
  * @key: Key for PRF
  * @key_len: Length of the key in bytes
  * @label: A unique label for each purpose of the PRF
@@ -28,16 +28,16 @@
  * This function is used to derive new, cryptographically separate keys from a
  * given key.
  */
-int sha256_prf(const u8 *key, size_t key_len, const char *label,
+int rtw_sha256_prf(const u8 *key, size_t key_len, const char *label,
 		const u8 *data, size_t data_len, u8 *buf, size_t buf_len)
 {
-	return sha256_prf_bits(key, key_len, label, data, data_len, buf,
+	return rtw_sha256_prf_bits(key, key_len, label, data, data_len, buf,
 			       buf_len * 8);
 }
 
 
 /**
- * sha256_prf_bits - IEEE Std 802.11-2012, 11.6.1.7.2 Key derivation function
+ * rtw_sha256_prf_bits - IEEE Std 802.11-2012, 11.6.1.7.2 Key derivation function
  * @key: Key for KDF
  * @key_len: Length of the key in bytes
  * @label: A unique label for each purpose of the PRF
@@ -52,7 +52,7 @@ int sha256_prf(const u8 *key, size_t key_len, const char *label,
  * significant 1-7 bits of the last octet in the output are not part of the
  * requested output.
  */
-int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
+int rtw_sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
 		    const u8 *data, size_t data_len, u8 *buf,
 		    size_t buf_len_bits)
 {
@@ -79,12 +79,12 @@ int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
 		plen = buf_len - pos;
 		WPA_PUT_LE16(counter_le, counter);
 		if (plen >= SHA256_MAC_LEN) {
-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
+			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
 					       &buf[pos]) < 0)
 				return -1;
 			pos += SHA256_MAC_LEN;
 		} else {
-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
+			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
 					       hash) < 0)
 				return -1;
 			os_memcpy(&buf[pos], hash, plen);

--- a/core/crypto/sha256.c
+++ b/core/crypto/sha256.c
@@ -14,7 +14,7 @@
 
 
 /**
- * hmac_sha256_vector - HMAC-SHA256 over data vector (RFC 2104)
+ * rtw_hmac_sha256_vector - HMAC-SHA256 over data vector (RFC 2104)
  * @key: Key for HMAC operations
  * @key_len: Length of the key in bytes
  * @num_elem: Number of elements in the data vector
@@ -23,7 +23,7 @@
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac)
 {
 	unsigned char k_pad[64]; /* padding - key XORd with ipad/opad */
@@ -89,7 +89,7 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 
 
 /**
- * hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
+ * rtw_hmac_sha256 - HMAC-SHA256 over data buffer (RFC 2104)
  * @key: Key for HMAC operations
  * @key_len: Length of the key in bytes
  * @data: Pointers to the data area
@@ -97,8 +97,8 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac)
 {
-	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
+	return rtw_hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
 }

--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -11,19 +11,19 @@
 
 #define SHA256_MAC_LEN 32
 
-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac);
-int sha256_prf(const u8 *key, size_t key_len, const char *label,
+int rtw_sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);
-int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
+int rtw_sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
 		    const u8 *data, size_t data_len, u8 *buf,
 		    size_t buf_len_bits);
-void tls_prf_sha256(const u8 *secret, size_t secret_len,
+void rtw_tls_prf_sha256(const u8 *secret, size_t secret_len,
 		    const char *label, const u8 *seed, size_t seed_len,
 		    u8 *out, size_t outlen);
-int hmac_sha256_kdf(const u8 *secret, size_t secret_len,
+int rtw_hmac_sha256_kdf(const u8 *secret, size_t secret_len,
 		    const char *label, const u8 *seed, size_t seed_len,
 		    u8 *out, size_t outlen);
 

--- a/core/rtw_swcrypto.c
+++ b/core/rtw_swcrypto.c
@@ -291,6 +291,6 @@ void _tdls_generate_tpk(void *sta, const u8 *own_addr, const u8 *bssid)
 
 	_rtw_memcpy(data + 2 * ETH_ALEN, bssid, ETH_ALEN);
 
-	sha256_prf(key_input, SHA256_MAC_LEN, "TDLS PMK", data, sizeof(data), (u8 *)&psta->tpk, sizeof(psta->tpk));
+	rtw_sha256_prf(key_input, SHA256_MAC_LEN, "TDLS PMK", data, sizeof(data), (u8 *)&psta->tpk, sizeof(psta->tpk));
 }
 #endif /* CONFIG_TDLS */

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -358,7 +358,7 @@ static inline void timer_hdl(unsigned long cntx)
 #endif
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
-	_timer *ptimer = from_timer(ptimer, in_timer, timer);
+	_timer *ptimer = container_of(in_timer, _timer, timer);
 #else
 	_timer *ptimer = (_timer *)cntx;
 #endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3601,7 +3601,11 @@ static void cfg80211_rtw_abort_scan(struct wiphy *wiphy,
 }
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, int link_id, u32 changed)
+#else
 static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+#endif
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -4586,6 +4590,9 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+	int link_id,
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
 	enum nl80211_tx_power_setting type, int mbm)
 #else
@@ -4648,7 +4655,10 @@ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+	int link_id,
+	unsigned int link_mask,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))
 	unsigned int link_id,
 #endif
 	int *dbm)


### PR DESCRIPTION
This commit resolves compilation errors when building the driver against Linux kernel 6.18.4, ensuring the driver works with the latest kernel versions.

Changes made:

1. Timer API compatibility (include/osdep_service_linux.h)
   - Replaced deprecated from_timer() with container_of() for kernel 6.18+
   - The from_timer() macro no longer exists in recent kernels

2. SHA256 function naming conflicts (core/crypto/*)
   - Renamed driver crypto functions to avoid conflicts with kernel's built-in crypto implementations: * hmac_sha256 → rtw_hmac_sha256 * hmac_sha256_vector → rtw_hmac_sha256_vector * sha256_prf → rtw_sha256_prf * sha256_prf_bits → rtw_sha256_prf_bits
   - Updated all call sites in core/rtw_swcrypto.c

3. cfg80211 wireless API updates (os_dep/linux/ioctl_cfg80211.c)
   - Updated cfg80211_rtw_set_wiphy_params() to accept link_id parameter
   - Updated cfg80211_rtw_set_txpower() to accept link_id parameter
   - Updated cfg80211_rtw_get_txpower() to accept link_id and link_mask
   - These changes support the new multi-link operation API in kernel 6.18

4. Documentation (README.md)
   - Updated kernel compatibility information

Tested on:
- Linux kernel 6.18.4
- TP-Link Archer T4U ver.3 (USB ID 2357:0115)
- Driver loads successfully and scans for networks

All changes are backward compatible with older kernel versions through version checks using LINUX_VERSION_CODE macros.