### PR TITLE
Fix compilation error for Kernel 6.17+ by updating cfg80211 API version check

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3601,7 +3601,7 @@ static void cfg80211_rtw_abort_scan(struct wiphy *wiphy,
 }
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
 static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, int link_id, u32 changed)
 #else
 static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
@@ -4590,7 +4590,7 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
 	int link_id,
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
@@ -4655,7 +4655,7 @@ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
 	int link_id,
 	unsigned int link_mask,
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0))


### PR DESCRIPTION
## Overview
This repository contains a modified version of the `rtl88x2bu` driver source code (originally from `morrownr/88x2bu-20210702`) and the successfully compiled kernel module (`88x2bu.ko.zst`) for Ubuntu 24.04 (Kernel `6.17.0-35-generic`).

## Issue
When attempting to compile the original driver source on Kernel `6.17.0-35-generic`, DKMS build failed with incompatible pointer type errors in `os_dep/linux/ioctl_cfg80211.c`:
```text
error: initialization of ‘int (*)(struct wiphy *, int,  u32)’ from incompatible pointer type ‘int (*)(struct wiphy *, u32)’
error: initialization of ‘int (*)(struct wiphy *, struct wireless_dev *, int,  enum nl80211_tx_power_setting,  int)’ from incompatible pointer type
```
This failure occurs because the `cfg80211` API in Linux kernel changed (introducing a new `link_id` parameter to functions like `set_wiphy_params`, `set_tx_power`, and `get_tx_power`). The original code incorrectly assumed this API change was introduced in kernel `6.18.0`. However, the API changes are present in kernel `6.17.0` (and some backported 6.x kernels).

## The Fix (Pull Request Details)
**File Modified**: `os_dep/linux/ioctl_cfg80211.c`

**Change**:
Updated the preprocessor directives checking the `LINUX_VERSION_CODE` from `KERNEL_VERSION(6, 18, 0)` to `KERNEL_VERSION(6, 17, 0)` to correctly handle the updated API signature on 6.17.0 kernels.

**Diff / What to submit in the PR:**
```diff
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
```
*(Note: A global search-and-replace was performed in `ioctl_cfg80211.c` for `KERNEL_VERSION(6, 18, 0)` -> `KERNEL_VERSION(6, 17, 0)` to fix `set_wiphy_params`, `set_tx_power`, and `get_tx_power`).*

## Files Included in this Directory
- `88x2bu-modified.tar.gz`: The full modified source code repository.
- `88x2bu.ko.zst`: The compiled kernel module ready for deployment.
- `ReadME.MD`: This file outlining the PR details.