### PR TITLE
Fix compilation for Linux Kernel 7.1.x (cfg80211 wdev API & PPPoE arrays)

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -89,7 +89,7 @@ static unsigned char *__nat25_find_pppoe_tag(struct pppoe_hdr *ph, unsigned shor
 	unsigned char *cur_ptr, *start_ptr;
 	unsigned short tagLen, tagType;
 
-	start_ptr = cur_ptr = (unsigned char *)ph->tag;
+	start_ptr = cur_ptr = (unsigned char *)((unsigned char *)(ph + 1));
 	while ((cur_ptr - start_ptr) < ntohs(ph->length)) {
 		/* prevent un-alignment access */
 		tagType = (unsigned short)((cur_ptr[0] << 8) + cur_ptr[1]);
@@ -115,9 +115,9 @@ static int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_tag *tag)
 
 	skb_put(skb, data_len);
 	/* have a room for new tag */
-	memmove(((unsigned char *)ph->tag + data_len), (unsigned char *)ph->tag, ntohs(ph->length));
+	memmove(((unsigned char *)((unsigned char *)(ph + 1)) + data_len), (unsigned char *)((unsigned char *)(ph + 1)), ntohs(ph->length));
 	ph->length = htons(ntohs(ph->length) + data_len);
-	memcpy((unsigned char *)ph->tag, tag, data_len);
+	memcpy((unsigned char *)((unsigned char *)(ph + 1)), tag, data_len);
 	return data_len;
 }
 
@@ -1150,8 +1150,8 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 								return -1;
 							}
 
-							memcpy(tag->tag_data + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
-							       pOldTag->tag_data, old_tag_len);
+							memcpy(((unsigned char *)(tag + 1)) + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
+							       ((unsigned char *)(pOldTag + 1)), old_tag_len);
 
 							if (skb_pull_and_merge(skb, (unsigned char *)pOldTag, TAG_HDR_LEN + old_tag_len) < 0) {
 								DEBUG_ERR("call skb_pull_and_merge() failed in PADI/R packet!\n");
@@ -1164,9 +1164,9 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						tag->tag_len = htons(MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN + old_tag_len);
 
 						/* insert the magic_code+client mac in relay tag */
-						pMagic = (unsigned short *)tag->tag_data;
+						pMagic = (unsigned short *)((unsigned char *)(tag + 1));
 						*pMagic = htons(MAGIC_CODE);
-						memcpy(tag->tag_data + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
+						memcpy(((unsigned char *)(tag + 1)) + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
 
 						/* Add relay tag */
 						if (__nat25_add_pppoe_tag(skb, tag) < 0)
@@ -1227,14 +1227,14 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						return -1;
 					}
 
-					pMagic = (unsigned short *)tag->tag_data;
+					pMagic = (unsigned short *)((unsigned char *)(tag + 1));
 					if (ntohs(*pMagic) != MAGIC_CODE) {
 						DEBUG_ERR("Can't find MAGIC_CODE in %s packet!\n",
 							(ph->code == PADO_CODE ? "PADO" : "PADS"));
 						return -1;
 					}
 
-					memcpy(skb->data, tag->tag_data + MAGIC_CODE_LEN, ETH_ALEN);
+					memcpy(skb->data, ((unsigned char *)(tag + 1)) + MAGIC_CODE_LEN, ETH_ALEN);
 
 					if (tagLen > MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN)
 						offset = TAG_HDR_LEN;

--- a/include/rtw_mlme_ext.h
+++ b/include/rtw_mlme_ext.h
@@ -274,7 +274,7 @@ enum TDLS_option {
 #if defined(CONFIG_ATMEL_RC_PATCH)
 	#define RTW_SCAN_NUM_OF_CH 2
 	#define RTW_BACK_OP_CH_MS 200
-#elseif defined(CONFIG_CUSTOMER_EZVIZ_CHIME2)
+#elif defined(CONFIG_CUSTOMER_EZVIZ_CHIME2)
 	#define RTW_SCAN_NUM_OF_CH 1
 	#define RTW_BACK_OP_CH_MS 200
 #else

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -812,7 +812,7 @@ __inline static union recv_frame *rxmem_to_recvframe(u8 *rxmem)
 __inline static union recv_frame *pkt_to_recvframe(_pkt *pkt)
 {
 
-	u8 *buf_star;
+	u8 *buf_star = NULL;
 	union recv_frame *precv_frame;
 	precv_frame = rxmem_to_recvframe((unsigned char *)buf_star);
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1922,6 +1922,19 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct wireless_dev *wdev
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
+	, int link_id
+#endif
+	, u8 key_index
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
+	, bool pairwise
+#endif
+	, const u8 *mac_addr, struct key_params *params)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -1932,6 +1945,8 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	, const u8 *mac_addr, struct key_params *params)
 {
+#endif
+
 	char *alg_name;
 	u32 param_len;
 	struct ieee_param *param = NULL;
@@ -2087,6 +2102,20 @@ addkey_end:
 
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct wireless_dev *wdev
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
+	, int link_id
+#endif
+	, u8 keyid
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
+	, bool pairwise
+#endif
+	, const u8 *mac_addr, void *cookie
+	, void (*callback)(void *cookie, struct key_params *))
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -2098,6 +2127,8 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
 	, const u8 *mac_addr, void *cookie
 	, void (*callback)(void *cookie, struct key_params *))
 {
+#endif
+
 #define GET_KEY_PARAM_FMT_S " keyid=%d"
 #define GET_KEY_PARAM_ARG_S , keyid
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
@@ -2278,6 +2309,19 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
+	int link_id,
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
+				u8 key_index, bool pairwise, const u8 *mac_addr)
+#else	/* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
+				u8 key_index, const u8 *mac_addr)
+#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	int link_id,
@@ -2288,6 +2332,8 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
 				u8 key_index, const u8 *mac_addr)
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
 {
+#endif
+
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
 
@@ -2353,6 +2399,16 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
+	struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
+	int link_id,
+#endif
+	u8 key_index)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 	struct net_device *ndev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
@@ -2360,6 +2416,8 @@ int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 #endif
 	u8 key_index)
 {
+#endif
+
 #define SET_DEF_KEY_PARAM_FMT " key_index=%d"
 #define SET_DEF_KEY_PARAM_ARG , key_index
 
@@ -2503,6 +2561,18 @@ static void rtw_cfg80211_fill_mesh_only_sta_info(struct mesh_plink_ent *plink, s
 }
 #endif /* CONFIG_RTW_MESH */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int cfg80211_rtw_get_station(struct wiphy *wiphy,
+	struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	u8 *mac,
+#else
+	const u8 *mac,
+#endif
+	struct station_info *sinfo)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 	struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -2512,6 +2582,8 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 #endif
 	struct station_info *sinfo)
 {
+#endif
+
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
@@ -5138,7 +5210,11 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+		cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#endif
 	}
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
@@ -5184,7 +5260,11 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+	cfg80211_del_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, da, GFP_ATOMIC);
+#else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
+#endif
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
 	freq = rtw_ch2freq(channel);
@@ -5672,6 +5752,17 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	u8 *mac,
+#else
+	const u8 *mac,
+#endif
+	struct station_parameters *params)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -5680,6 +5771,8 @@ static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	struct station_parameters *params)
 {
+#endif
+
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 #if defined(CONFIG_TDLS) || defined(CONFIG_RTW_MESH)
@@ -5818,7 +5911,11 @@ release_plink_ctl:
 
 			/* indicate new sta */
 			_rtw_memset(&sinfo, 0, sizeof(sinfo));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+			cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, mac, &sinfo, GFP_ATOMIC);
+#else
 			cfg80211_new_sta(ndev, mac, &sinfo, GFP_ATOMIC);
+#endif
 		}
 		goto exit;
 	}
@@ -5840,6 +5937,19 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	u8 *mac
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
+	const u8 *mac
+#else
+	struct station_del_parameters *params
+#endif
+)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
@@ -5850,6 +5960,8 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 )
 {
+#endif
+
 	int ret = 0;
 	_irqL irqL;
 	_list	*phead, *plist;
@@ -5966,6 +6078,17 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	u8 *mac,
+#else
+	const u8 *mac,
+#endif
+	struct station_parameters *params)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *ndev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -5974,6 +6097,8 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *n
 #endif
 	struct station_parameters *params)
 {
+#endif
+
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 	int ret = 0;
 
@@ -6032,9 +6157,17 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+		int idx, u8 *mac, struct station_info *sinfo)
+{
+	struct net_device *ndev = wdev->netdev;
+#else
 static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct net_device *ndev,
 		int idx, u8 *mac, struct station_info *sinfo)
 {
+#endif
+
 #define DBG_DUMP_STATION 0
 
 	int ret = 0;


### PR DESCRIPTION
This PR introduces backward-compatible macros to allow the driver to compile against bleeding-edge kernels (Tested successfully on 7.1.3 XanMod).

**Why this is necessary:**
While the mainline `rtw88` driver exists natively in modern kernels, it is highly unstable when operating as an Access Point on 5GHz/80MHz bands, suffering from severe dropouts. Keeping this out-of-tree vendor driver compiling on 7.x kernels is critical for users who rely on the 88x2bu chipset for reliable 5GHz AP mode functionality. 

**Changes:**
1. **`ioctl_cfg80211.c`:** Wrapped the `cfg80211_ops` callbacks with `#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))` macros. Newer kernels replaced the `struct net_device *ndev` pointer with `struct wireless_dev *wdev`. 
2. **`rtw_br_ext.c`:** Replaced zero-length array references (`ph->tag` and `tag_data`) with standard pointer arithmetic `(ph + 1)`. Modern kernels enforce C99 flexible arrays and purged zero-length arrays from `if_pppox.h`.
3. **`rtw_mlme_ext.h` & `rtw_recv.h`:** Fixed `#elif` preprocessor syntax and initialized dangling pointers to prevent strict Clang 21 build failures.