### PR TITLE
Fix build on kernel 7.0.x: gate cfg80211 wdev API at 7.1, not 7.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1922,7 +1922,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct wireless_dev *wdev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -2102,7 +2102,7 @@ addkey_end:
 
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct wireless_dev *wdev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -2309,7 +2309,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	int link_id,
@@ -2399,7 +2399,7 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
@@ -2561,7 +2561,7 @@ static void rtw_cfg80211_fill_mesh_only_sta_info(struct mesh_plink_ent *plink, s
 }
 #endif /* CONFIG_RTW_MESH */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -5210,7 +5210,7 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 		cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
 #else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
@@ -5260,7 +5260,7 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 	cfg80211_del_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, da, GFP_ATOMIC);
 #else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
@@ -5752,7 +5752,7 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -5911,7 +5911,7 @@ release_plink_ctl:
 
 			/* indicate new sta */
 			_rtw_memset(&sinfo, 0, sizeof(sinfo));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 			cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, mac, &sinfo, GFP_ATOMIC);
 #else
 			cfg80211_new_sta(ndev, mac, &sinfo, GFP_ATOMIC);
@@ -5937,7 +5937,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
@@ -6078,7 +6078,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -6157,7 +6157,7 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 		int idx, u8 *mac, struct station_info *sinfo)
 {


### PR DESCRIPTION
## Problem

Current `main` does not build on kernel 7.0.x. On Ubuntu with `7.0.0-28-generic`, an unmodified checkout of `249ca95` fails with 11 `-Werror=incompatible-pointer-types` errors:

```text
os_dep/linux/ioctl_cfg80211.c:10591:20: error: initialization of
  'int (*)(struct wiphy *, struct net_device *, int, u8, bool, const u8 *, struct key_params *)'
  from incompatible pointer type
  'int (*)(struct wiphy *, struct wireless_dev *, int, u8, bool, const u8 *, struct key_params *)'
os_dep/linux/ioctl_cfg80211.c:5214:69: error: passing argument 1 of 'cfg80211_new_sta' from incompatible pointer type
os_dep/linux/ioctl_cfg80211.c:5264:61: error: passing argument 1 of 'cfg80211_del_sta' from incompatible pointer type
```

## Cause

#277 converted the `cfg80211_ops` callbacks from `struct net_device *` to `struct wireless_dev *` and gated the change on `KERNEL_VERSION(7, 0, 0)`. That API change actually lands in **7.1**, which matches that PR's own title ("Fix compilation for Linux Kernel 7.1.x"), so 7.0.x is left taking the `wireless_dev` branch against a kernel that still expects `net_device`.

`linux-headers-7.0.0-28-generic`, `include/net/cfg80211.h:4925`:

```c
int	(*add_key)(struct wiphy *wiphy, struct net_device *netdev,
```

Affected callbacks: `add_key`, `get_key`, `del_key`, `set_default_mgmt_key`, `get_station`, `add_station`, `del_station`, `change_station`, `dump_station`, plus the `cfg80211_new_sta()` / `cfg80211_del_sta()` call sites.

## Fix

Move all 12 guards from `KERNEL_VERSION(7, 0, 0)` to `KERNEL_VERSION(7, 1, 0)`. No logic changes — only the version boundary moves, so 7.1+ keeps the exact behaviour #277 introduced. No other file in the tree carries a `7.0.0` guard.

## Testing

- `7.0.0-28-generic` (Ubuntu): fails to build before this patch, builds clean and links `88x2bu.ko` after it.
- Kernels below 7.0 are unaffected — the guarded branch was already not taken there.
- I do not have a 7.1 system to retest on; that path is unchanged by this patch.