### PR TITLE
Fix build on kernel 7.0: cfg80211 wdev guard should be 7.1, not 7.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1922,7 +1922,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct wireless_dev *wdev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -2102,7 +2102,7 @@ addkey_end:
 
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct wireless_dev *wdev
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	, int link_id
@@ -2309,7 +2309,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
 	int link_id,
@@ -2399,7 +2399,7 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) || defined(RHEL88))
@@ -2561,7 +2561,7 @@ static void rtw_cfg80211_fill_mesh_only_sta_info(struct mesh_plink_ent *plink, s
 }
 #endif /* CONFIG_RTW_MESH */
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -5210,7 +5210,7 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
 #endif
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 		cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
 #else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
@@ -5260,7 +5260,7 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 	cfg80211_del_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, da, GFP_ATOMIC);
 #else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
@@ -5752,7 +5752,7 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -5911,7 +5911,7 @@ release_plink_ctl:
 
 			/* indicate new sta */
 			_rtw_memset(&sinfo, 0, sizeof(sinfo));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 			cfg80211_new_sta(((_adapter *)rtw_netdev_priv(ndev))->rtw_wdev, mac, &sinfo, GFP_ATOMIC);
 #else
 			cfg80211_new_sta(ndev, mac, &sinfo, GFP_ATOMIC);
@@ -5937,7 +5937,7 @@ exit:
 	return ret;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
@@ -6078,7 +6078,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -6157,7 +6157,7 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct wireless_dev *wdev,
 		int idx, u8 *mac, struct station_info *sinfo)
 {


### PR DESCRIPTION
## Problem

On a 7.0 kernel the build fails with 11 `-Werror=incompatible-pointer-types` errors in `os_dep/linux/ioctl_cfg80211.c`:

```
os_dep/linux/ioctl_cfg80211.c:5214:69: error: passing argument 1 of 'cfg80211_new_sta' from incompatible pointer type
os_dep/linux/ioctl_cfg80211.c:5264:61: error: passing argument 1 of 'cfg80211_del_sta' from incompatible pointer type
os_dep/linux/ioctl_cfg80211.c:10591:20: error: initialization of 'int (*)(struct wiphy *, struct net_device *, ...)'
  from incompatible pointer type 'int (*)(struct wiphy *, struct wireless_dev *, ...)'
...
make[4]: *** [scripts/Makefile.build:289: os_dep/linux/ioctl_cfg80211.o] Error 1
```

## Cause

8426214 ("Fix compilation for Linux Kernel 7.1.x: cfg80211 wdev API and C99 flex arrays") gated the new `struct wireless_dev *`-based cfg80211 callbacks behind `KERNEL_VERSION(7, 0, 0)`. As the commit title says, the wdev conversion is a 7.1 change — so the guard is one minor version too low, and 7.0 kernels take the new path against headers that still declare the old one.

From `include/net/cfg80211.h` on 7.0.0-28-generic:

```c
int (*add_key)(struct wiphy *wiphy, struct net_device *netdev,
               int link_id, u8 key_index, bool pairwise,
               const u8 *mac_addr, struct key_params *params);

void cfg80211_new_sta(struct net_device *dev, const u8 *mac_addr,
                      struct station_info *sinfo, gfp_t gfp);
```

Still `net_device` on both counts.

## Fix

Bump all 12 guards in `ioctl_cfg80211.c` from `KERNEL_VERSION(7, 0, 0)` to `KERNEL_VERSION(7, 1, 0)`. Only that file is touched; every changed line is one of the guards introduced by 8426214.

## Testing

Built and installed via DKMS against Ubuntu 24.04, kernel 7.0.0-28-generic, gcc 13.3.0. Module loads, and the adapter (ASUS `0b05:184c`, RTL8822BU) associates and scans normally.

One caveat worth stating plainly: **I could not test on 7.1**, having no 7.1 kernel available. This change leaves the 7.1+ path exactly as 8426214 wrote it and only restores the pre-existing `net_device` path for 7.0, so it should be a no-op there — but that half is reasoned, not verified, and deserves a second pair of eyes from someone running 7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)