### PR TITLE
Fix build on 6.12.101 and later in the 6.12 series

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -7057,7 +7057,7 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
 
 static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 101))
 	, struct net_device *dev
 	, struct cfg80211_chan_def *chandef
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))


### PR DESCRIPTION
@morrownr As offered.

`set_monitor_channel` gained a `struct net_device *dev` argument in 9c4f83092775, which is 6.13. 6.12 stable took it at 6.12.101 as a dependency of an unrelated deadlock fix, so the 6.13.0 gate misses that window. 6.13 and newer were never affected.

Built both ways against 6.12.100 and 6.12.101 from kernel.org tonight: stock fails on 6.12.101 only, at `.set_monitor_channel = cfg80211_rtw_set_monitor_channel`, and this clears it without touching 6.12.100.

6.12.101 is the exact boundary, re-checked tonight against the current tips: 6.12.104, 6.18.45 and 7.1.9 take the new argument, and 6.6.152, 6.1.183, 5.15.216 and 5.10.265 do not. 6.12.100 does not either, which is the cell that matters. 6.13.0 sorts above 6.12.101, so the one check covers both.

Same change already merged as 8821au-20210708#209, rtl8852bu-20250826#19 and rtl8852cu-20251113#16.
